### PR TITLE
using i64bit namespace to prevent conflict with mozilla-sdk 64bit type

### DIFF
--- a/third_party/chromium_base/base/basictypes.h
+++ b/third_party/chromium_base/base/basictypes.h
@@ -30,9 +30,15 @@ typedef int                 int32;
 // The NSPR system headers define 64-bit as |long| when possible.  In order to
 // not have typedef mismatches, we do the same on LP64.
 #if __LP64__
+namespace i64Bit
+{
 typedef long                int64;
+}
 #else
+namespace i64Bit
+{
 typedef long long           int64;
+}
 #endif
 
 // NOTE: unsigned types are DANGEROUS in loops and other arithmetical
@@ -78,8 +84,8 @@ const  int16 kint16min  = (( int16) 0x8000);
 const  int16 kint16max  = (( int16) 0x7FFF);
 const  int32 kint32min  = (( int32) 0x80000000);
 const  int32 kint32max  = (( int32) 0x7FFFFFFF);
-const  int64 kint64min  = (( int64) GG_LONGLONG(0x8000000000000000));
-const  int64 kint64max  = (( int64) GG_LONGLONG(0x7FFFFFFFFFFFFFFF));
+const  i64Bit::int64 kint64min  = (( i64Bit::int64) GG_LONGLONG(0x8000000000000000));
+const  i64Bit::int64 kint64max  = (( i64Bit::int64) GG_LONGLONG(0x7FFFFFFFFFFFFFFF));
 
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class

--- a/third_party/chromium_base/base/file_util.cc
+++ b/third_party/chromium_base/base/file_util.cc
@@ -184,7 +184,7 @@ FILE* CreateAndOpenTemporaryFile(FilePath* path) {
   return CreateAndOpenTemporaryFileInDir(directory, path);
 }
 
-bool GetFileSize(const FilePath& file_path, int64* file_size) {
+bool GetFileSize(const FilePath& file_path, i64Bit::int64* file_size) {
   base::PlatformFileInfo info;
   if (!GetFileInfo(file_path, &info))
     return false;
@@ -273,8 +273,8 @@ bool ContainsPath(const FilePath &parent, const FilePath& child) {
   return true;
 }
 
-int64 ComputeDirectorySize(const FilePath& root_path) {
-  int64 running_size = 0;
+i64Bit::int64 ComputeDirectorySize(const FilePath& root_path) {
+  i64Bit::int64 running_size = 0;
   FileEnumerator file_iter(root_path, true, FileEnumerator::FILES);
   for (FilePath current = file_iter.Next(); !current.empty();
        current = file_iter.Next()) {
@@ -290,9 +290,9 @@ int64 ComputeDirectorySize(const FilePath& root_path) {
   return running_size;
 }
 
-int64 ComputeFilesSize(const FilePath& directory,
+i64Bit::int64 ComputeFilesSize(const FilePath& directory,
                        const FilePath::StringType& pattern) {
-  int64 running_size = 0;
+  i64Bit::int64 running_size = 0;
   FileEnumerator file_iter(directory, false, FileEnumerator::FILES, pattern);
   for (FilePath current = file_iter.Next(); !current.empty();
        current = file_iter.Next()) {

--- a/third_party/chromium_base/base/file_util.h
+++ b/third_party/chromium_base/base/file_util.h
@@ -81,7 +81,7 @@ int CountFilesCreatedAfter(const FilePath& path,
 //
 // This function is implemented using the FileEnumerator class so it is not
 // particularly speedy in any platform.
-int64 ComputeDirectorySize(const FilePath& root_path);
+i64Bit::int64 ComputeDirectorySize(const FilePath& root_path);
 
 // Returns the total number of bytes used by all files matching the provided
 // |pattern|, on this |directory| (without recursion). If the path does not
@@ -89,7 +89,7 @@ int64 ComputeDirectorySize(const FilePath& root_path);
 //
 // This function is implemented using the FileEnumerator class so it is not
 // particularly speedy in any platform.
-int64 ComputeFilesSize(const FilePath& directory,
+i64Bit::int64 ComputeFilesSize(const FilePath& directory,
                        const FilePath::StringType& pattern);
 
 // Deletes the given path, whether it's a file or a directory.
@@ -290,7 +290,7 @@ bool CreateTemporaryDirInDir(const FilePath& base_dir,
 bool CreateDirectory(const FilePath& full_path);
 
 // Returns the file size. Returns true on success.
-bool GetFileSize(const FilePath& file_path, int64* file_size);
+bool GetFileSize(const FilePath& file_path, i64Bit::int64* file_size);
 
 // Returns true if the given path's base name is ".".
 bool IsDot(const FilePath& path);

--- a/third_party/chromium_base/base/message_loop.h
+++ b/third_party/chromium_base/base/message_loop.h
@@ -154,13 +154,13 @@ class MessageLoop : public base::MessagePump::Delegate {
       const tracked_objects::Location& from_here, Task* task);
 
   void PostDelayedTask(
-      const tracked_objects::Location& from_here, Task* task, int64 delay_ms);
+      const tracked_objects::Location& from_here, Task* task, i64Bit::int64 delay_ms);
 
   void PostNonNestableTask(
       const tracked_objects::Location& from_here, Task* task);
 
   void PostNonNestableDelayedTask(
-      const tracked_objects::Location& from_here, Task* task, int64 delay_ms);
+      const tracked_objects::Location& from_here, Task* task, i64Bit::int64 delay_ms);
 
   // A variant on PostTask that deletes the given object.  This is useful
   // if the object needs to live until the next run of the MessageLoop (for
@@ -417,7 +417,7 @@ class MessageLoop : public base::MessagePump::Delegate {
 
   // Post a task to our incomming queue.
   void PostTask_Helper(const tracked_objects::Location& from_here, Task* task,
-                       int64 delay_ms, bool nestable);
+                       i64Bit::int64 delay_ms, bool nestable);
 
   // Start recording histogram info about events and action IF it was enabled
   // and IF the statistics recorder can accept a registration of our histogram.

--- a/third_party/chromium_base/base/message_loop_proxy.h
+++ b/third_party/chromium_base/base/message_loop_proxy.h
@@ -31,13 +31,13 @@ class MessageLoopProxy
   virtual bool PostTask(const tracked_objects::Location& from_here,
                         Task* task) = 0;
   virtual bool PostDelayedTask(const tracked_objects::Location& from_here,
-                               Task* task, int64 delay_ms) = 0;
+                               Task* task, i64Bit::int64 delay_ms) = 0;
   virtual bool PostNonNestableTask(const tracked_objects::Location& from_here,
                                    Task* task) = 0;
   virtual bool PostNonNestableDelayedTask(
       const tracked_objects::Location& from_here,
       Task* task,
-      int64 delay_ms) = 0;
+      i64Bit::int64 delay_ms) = 0;
   // A method which checks if the caller is currently running in the thread that
   // this proxy represents.
   virtual bool BelongsToCurrentThread() = 0;

--- a/third_party/chromium_base/base/pickle.cc
+++ b/third_party/chromium_base/base/pickle.cc
@@ -185,7 +185,7 @@ bool Pickle::ReadUInt32(void** iter, uint32* result) const {
   return true;
 }
 
-bool Pickle::ReadInt64(void** iter, int64* result) const {
+bool Pickle::ReadInt64(void** iter, i64Bit::int64* result) const {
   DCHECK(iter);
   if (!*iter)
     *iter = const_cast<char*>(payload());

--- a/third_party/chromium_base/base/pickle.h
+++ b/third_party/chromium_base/base/pickle.h
@@ -70,7 +70,7 @@ class Pickle {
   bool ReadSize(void** iter, size_t* result) const;
   bool ReadUInt16(void** iter, uint16* result) const;
   bool ReadUInt32(void** iter, uint32* result) const;
-  bool ReadInt64(void** iter, int64* result) const;
+  bool ReadInt64(void** iter, i64Bit::int64* result) const;
   bool ReadUInt64(void** iter, i64Bit::uint64* result) const;
   bool ReadString(void** iter, std::string* result) const;
   bool ReadWString(void** iter, std::wstring* result) const;
@@ -104,7 +104,7 @@ class Pickle {
   bool WriteUInt32(uint32 value) {
     return WriteBytes(&value, sizeof(value));
   }
-  bool WriteInt64(int64 value) {
+  bool WriteInt64(i64Bit::int64 value) {
     return WriteBytes(&value, sizeof(value));
   }
   bool WriteUInt64(i64Bit::uint64 value) {

--- a/third_party/chromium_base/base/platform_file.h
+++ b/third_party/chromium_base/base/platform_file.h
@@ -75,7 +75,7 @@ struct PlatformFileInfo {
   ~PlatformFileInfo();
 
   // The size of the file in bytes.  Undefined when is_directory is true.
-  int64 size;
+  i64Bit::int64 size;
 
   // True if the file corresponds to a directory.
   bool is_directory;
@@ -110,18 +110,18 @@ bool ClosePlatformFile(PlatformFile file);
 
 // Reads the given number of bytes (or until EOF is reached) starting with the
 // given offset. Returns the number of bytes read, or -1 on error.
-int ReadPlatformFile(PlatformFile file, int64 offset, char* data, int size);
+int ReadPlatformFile(PlatformFile file, i64Bit::int64 offset, char* data, int size);
 
 // Writes the given buffer into the file at the given offset, overwritting any
 // data that was previously there. Returns the number of bytes written, or -1
 // on error.
-int WritePlatformFile(PlatformFile file, int64 offset,
+int WritePlatformFile(PlatformFile file, i64Bit::int64 offset,
                       const char* data, int size);
 
 // Truncates the given file to the given length. If |length| is greater than
 // the current size of the file, the file is extended with zeros. If the file
 // doesn't exist, |false| is returned.
-bool TruncatePlatformFile(PlatformFile file, int64 length);
+bool TruncatePlatformFile(PlatformFile file, i64Bit::int64 length);
 
 // Flushes the buffers of the given file.
 bool FlushPlatformFile(PlatformFile file);

--- a/third_party/chromium_base/base/platform_file_posix.cc
+++ b/third_party/chromium_base/base/platform_file_posix.cc
@@ -144,14 +144,14 @@ bool ClosePlatformFile(PlatformFile file) {
   return !close(file);
 }
 
-int ReadPlatformFile(PlatformFile file, int64 offset, char* data, int size) {
+int ReadPlatformFile(PlatformFile file, i64Bit::int64 offset, char* data, int size) {
   if (file < 0)
     return -1;
 
   return HANDLE_EINTR(pread(file, data, size, offset));
 }
 
-int WritePlatformFile(PlatformFile file, int64 offset,
+int WritePlatformFile(PlatformFile file, i64Bit::int64 offset,
                       const char* data, int size) {
   if (file < 0)
     return -1;
@@ -159,7 +159,7 @@ int WritePlatformFile(PlatformFile file, int64 offset,
   return HANDLE_EINTR(pwrite(file, data, size, offset));
 }
 
-bool TruncatePlatformFile(PlatformFile file, int64 length) {
+bool TruncatePlatformFile(PlatformFile file, i64Bit::int64 length) {
   return ((file >= 0) && !HANDLE_EINTR(ftruncate(file, length)));
 }
 

--- a/third_party/chromium_base/base/string_number_conversions.cc
+++ b/third_party/chromium_base/base/string_number_conversions.cc
@@ -294,18 +294,18 @@ typedef BaseIteratorRangeToNumberTraits<std::string::const_iterator, int, 10>
     IteratorRangeToIntTraits;
 typedef BaseIteratorRangeToNumberTraits<string16::const_iterator, int, 10>
     WideIteratorRangeToIntTraits;
-typedef BaseIteratorRangeToNumberTraits<std::string::const_iterator, int64, 10>
+typedef BaseIteratorRangeToNumberTraits<std::string::const_iterator, i64Bit::int64, 10>
     IteratorRangeToInt64Traits;
-typedef BaseIteratorRangeToNumberTraits<string16::const_iterator, int64, 10>
+typedef BaseIteratorRangeToNumberTraits<string16::const_iterator, i64Bit::int64, 10>
     WideIteratorRangeToInt64Traits;
 
 typedef BaseIteratorRangeToNumberTraits<const char*, int, 10>
     CharBufferToIntTraits;
 typedef BaseIteratorRangeToNumberTraits<const char16*, int, 10>
     WideCharBufferToIntTraits;
-typedef BaseIteratorRangeToNumberTraits<const char*, int64, 10>
+typedef BaseIteratorRangeToNumberTraits<const char*, i64Bit::int64, 10>
     CharBufferToInt64Traits;
-typedef BaseIteratorRangeToNumberTraits<const char16*, int64, 10>
+typedef BaseIteratorRangeToNumberTraits<const char16*, i64Bit::int64, 10>
     WideCharBufferToInt64Traits;
 
 template<typename ITERATOR>
@@ -362,13 +362,13 @@ string16 UintToString16(unsigned int value) {
       IntToString(value);
 }
 
-std::string Int64ToString(int64 value) {
-  return IntToStringT<std::string, int64, i64Bit::uint64, true>::
+std::string Int64ToString(i64Bit::int64 value) {
+  return IntToStringT<std::string, i64Bit::int64, i64Bit::uint64, true>::
       IntToString(value);
 }
 
-string16 Int64ToString16(int64 value) {
-  return IntToStringT<string16, int64, i64Bit::uint64, true>::IntToString(value);
+string16 Int64ToString16(i64Bit::int64 value) {
+  return IntToStringT<string16, i64Bit::int64, i64Bit::uint64, true>::IntToString(value);
 }
 
 std::string Uint64ToString(i64Bit::uint64 value) {
@@ -427,39 +427,39 @@ bool StringToInt(const char16* begin, const char16* end, int* output) {
                                                                   output);
 }
 
-bool StringToInt64(const std::string& input, int64* output) {
+bool StringToInt64(const std::string& input, i64Bit::int64* output) {
   return IteratorRangeToNumber<IteratorRangeToInt64Traits>::Invoke(
     input.begin(), input.end(), output);
 }
 
 bool StringToInt64(std::string::const_iterator begin,
                  std::string::const_iterator end,
-                 int64* output) {
+                 i64Bit::int64* output) {
   return IteratorRangeToNumber<IteratorRangeToInt64Traits>::Invoke(begin,
                                                                  end,
                                                                  output);
 }
 
-bool StringToInt64(const char* begin, const char* end, int64* output) {
+bool StringToInt64(const char* begin, const char* end, i64Bit::int64* output) {
   return IteratorRangeToNumber<CharBufferToInt64Traits>::Invoke(begin,
                                                               end,
                                                               output);
 }
 
-bool StringToInt64(const string16& input, int64* output) {
+bool StringToInt64(const string16& input, i64Bit::int64* output) {
   return IteratorRangeToNumber<WideIteratorRangeToInt64Traits>::Invoke(
     input.begin(), input.end(), output);
 }
 
 bool StringToInt64(string16::const_iterator begin,
                  string16::const_iterator end,
-                 int64* output) {
+                 i64Bit::int64* output) {
   return IteratorRangeToNumber<WideIteratorRangeToInt64Traits>::Invoke(begin,
                                                                      end,
                                                                      output);
 }
 
-bool StringToInt64(const char16* begin, const char16* end, int64* output) {
+bool StringToInt64(const char16* begin, const char16* end, i64Bit::int64* output) {
   return IteratorRangeToNumber<WideCharBufferToInt64Traits>::Invoke(begin,
                                                                   end,
                                                                   output);

--- a/third_party/chromium_base/base/string_number_conversions.h
+++ b/third_party/chromium_base/base/string_number_conversions.h
@@ -33,8 +33,8 @@ string16 IntToString16(int value);
 std::string UintToString(unsigned value);
 string16 UintToString16(unsigned value);
 
-std::string Int64ToString(int64 value);
-string16 Int64ToString16(int64 value);
+std::string Int64ToString(i64Bit::int64 value);
+string16 Int64ToString16(i64Bit::int64 value);
 
 std::string Uint64ToString(i64Bit::uint64 value);
 string16 Uint64ToString16(i64Bit::uint64 value);
@@ -69,17 +69,17 @@ bool StringToInt(string16::const_iterator begin,
                  int* output);
 bool StringToInt(const char16* begin, const char16* end, int* output);
 
-bool StringToInt64(const std::string& input, int64* output);
+bool StringToInt64(const std::string& input, i64Bit::int64* output);
 bool StringToInt64(std::string::const_iterator begin,
                    std::string::const_iterator end,
-                   int64* output);
-bool StringToInt64(const char* begin, const char* end, int64* output);
+                   i64Bit::int64* output);
+bool StringToInt64(const char* begin, const char* end, i64Bit::int64* output);
 
-bool StringToInt64(const string16& input, int64* output);
+bool StringToInt64(const string16& input, i64Bit::int64* output);
 bool StringToInt64(string16::const_iterator begin,
                    string16::const_iterator end,
-                   int64* output);
-bool StringToInt64(const char16* begin, const char16* end, int64* output);
+                   i64Bit::int64* output);
+bool StringToInt64(const char16* begin, const char16* end, i64Bit::int64* output);
 
 // For floating-point conversions, only conversions of input strings in decimal
 // form are defined to work.  Behavior with strings representing floating-point

--- a/third_party/chromium_base/base/string_util.cc
+++ b/third_party/chromium_base/base/string_util.cc
@@ -620,11 +620,11 @@ bool EndsWith(const string16& str, const string16& search,
 }
 #endif
 
-DataUnits GetByteDisplayUnits(int64 bytes) {
+DataUnits GetByteDisplayUnits(i64Bit::int64 bytes) {
   // The byte thresholds at which we display amounts.  A byte count is displayed
   // in unit U when kUnitThresholds[U] <= bytes < kUnitThresholds[U+1].
   // This must match the DataUnits enum.
-  static const int64 kUnitThresholds[] = {
+  static const i64Bit::int64 kUnitThresholds[] = {
     0,              // DATA_UNITS_BYTE,
     3*1024,         // DATA_UNITS_KIBIBYTE,
     2*1024*1024,    // DATA_UNITS_MEBIBYTE,
@@ -662,7 +662,7 @@ static const char* const kSpeedStrings[] = {
   "GB/s"
 };
 
-string16 FormatBytesInternal(int64 bytes,
+string16 FormatBytesInternal(i64Bit::int64 bytes,
                              DataUnits units,
                              bool show_units,
                              const char* const* suffix) {
@@ -693,11 +693,11 @@ string16 FormatBytesInternal(int64 bytes,
   return ASCIIToUTF16(ret);
 }
 
-string16 FormatBytes(int64 bytes, DataUnits units, bool show_units) {
+string16 FormatBytes(i64Bit::int64 bytes, DataUnits units, bool show_units) {
   return FormatBytesInternal(bytes, units, show_units, kByteStrings);
 }
 
-string16 FormatSpeed(int64 bytes, DataUnits units, bool show_units) {
+string16 FormatSpeed(i64Bit::int64 bytes, DataUnits units, bool show_units) {
   return FormatBytesInternal(bytes, units, show_units, kSpeedStrings);
 }
 

--- a/third_party/chromium_base/base/string_util.h
+++ b/third_party/chromium_base/base/string_util.h
@@ -418,22 +418,22 @@ enum DataUnits {
 
 // Return the unit type that is appropriate for displaying the amount of bytes
 // passed in.
-DataUnits GetByteDisplayUnits(int64 bytes);
+DataUnits GetByteDisplayUnits(i64Bit::int64 bytes);
 
 // Return a byte string in human-readable format, displayed in units appropriate
 // specified by 'units', with an optional unit suffix.
 // Ex: FormatBytes(512, DATA_UNITS_KIBIBYTE, true) => "0.5 KB"
 // Ex: FormatBytes(10*1024, DATA_UNITS_MEBIBYTE, false) => "0.1"
-string16 FormatBytes(int64 bytes, DataUnits units, bool show_units);
+string16 FormatBytes(i64Bit::int64 bytes, DataUnits units, bool show_units);
 
 // As above, but with "/s" units.
 // Ex: FormatSpeed(512, DATA_UNITS_KIBIBYTE, true) => "0.5 KB/s"
 // Ex: FormatSpeed(10*1024, DATA_UNITS_MEBIBYTE, false) => "0.1"
-string16 FormatSpeed(int64 bytes, DataUnits units, bool show_units);
+string16 FormatSpeed(i64Bit::int64 bytes, DataUnits units, bool show_units);
 
 // Return a number formated with separators in the user's locale way.
 // Ex: FormatNumber(1234567) => 1,234,567
-string16 FormatNumber(int64 number);
+string16 FormatNumber(i64Bit::int64 number);
 
 // Starting at |start_offset| (usually 0), replace the first instance of
 // |find_this| with |replace_with|.

--- a/third_party/chromium_base/base/synchronization/condition_variable_posix.cc
+++ b/third_party/chromium_base/base/synchronization/condition_variable_posix.cc
@@ -40,7 +40,7 @@ void ConditionVariable::Wait() {
 }
 
 void ConditionVariable::TimedWait(const TimeDelta& max_time) {
-  int64 usecs = max_time.InMicroseconds();
+  i64Bit::int64 usecs = max_time.InMicroseconds();
 
   // The timeout argument to pthread_cond_timedwait is in absolute time.
   struct timeval now;

--- a/third_party/chromium_base/base/time.cc
+++ b/third_party/chromium_base/base/time.cc
@@ -28,7 +28,7 @@ double TimeDelta::InSecondsF() const {
   return static_cast<double>(delta_) / Time::kMicrosecondsPerSecond;
 }
 
-int64 TimeDelta::InSeconds() const {
+i64Bit::int64 TimeDelta::InSeconds() const {
   return delta_ / Time::kMicrosecondsPerSecond;
 }
 
@@ -36,16 +36,16 @@ double TimeDelta::InMillisecondsF() const {
   return static_cast<double>(delta_) / Time::kMicrosecondsPerMillisecond;
 }
 
-int64 TimeDelta::InMilliseconds() const {
+i64Bit::int64 TimeDelta::InMilliseconds() const {
   return delta_ / Time::kMicrosecondsPerMillisecond;
 }
 
-int64 TimeDelta::InMillisecondsRoundedUp() const {
+i64Bit::int64 TimeDelta::InMillisecondsRoundedUp() const {
   return (delta_ + Time::kMicrosecondsPerMillisecond - 1) /
       Time::kMicrosecondsPerMillisecond;
 }
 
-int64 TimeDelta::InMicroseconds() const {
+i64Bit::int64 TimeDelta::InMicroseconds() const {
   return delta_;
 }
 
@@ -68,7 +68,7 @@ time_t Time::ToTimeT() const {
 Time Time::FromDoubleT(double dt) {
   if (dt == 0)
     return Time();  // Preserve 0 so we can tell it doesn't exist.
-  return Time(static_cast<int64>((dt *
+  return Time(static_cast<i64Bit::int64>((dt *
                                   static_cast<double>(kMicrosecondsPerSecond)) +
                                  kTimeTToMicrosecondsOffset));
 }

--- a/third_party/chromium_base/base/time.h
+++ b/third_party/chromium_base/base/time.h
@@ -54,17 +54,17 @@ class TimeDelta {
   }
 
   // Converts units of time to TimeDeltas.
-  static TimeDelta FromDays(int64 days);
-  static TimeDelta FromHours(int64 hours);
-  static TimeDelta FromMinutes(int64 minutes);
-  static TimeDelta FromSeconds(int64 secs);
-  static TimeDelta FromMilliseconds(int64 ms);
-  static TimeDelta FromMicroseconds(int64 us);
+  static TimeDelta FromDays(i64Bit::int64 days);
+  static TimeDelta FromHours(i64Bit::int64 hours);
+  static TimeDelta FromMinutes(i64Bit::int64 minutes);
+  static TimeDelta FromSeconds(i64Bit::int64 secs);
+  static TimeDelta FromMilliseconds(i64Bit::int64 ms);
+  static TimeDelta FromMicroseconds(i64Bit::int64 us);
 
   // Returns the internal numeric value of the TimeDelta object. Please don't
   // use this and do arithmetic on it, as it is more error prone than using the
   // provided operators.
-  int64 ToInternalValue() const {
+  i64Bit::int64 ToInternalValue() const {
     return delta_;
   }
 
@@ -81,11 +81,11 @@ class TimeDelta {
   int InHours() const;
   int InMinutes() const;
   double InSecondsF() const;
-  int64 InSeconds() const;
+  i64Bit::int64 InSeconds() const;
   double InMillisecondsF() const;
-  int64 InMilliseconds() const;
-  int64 InMillisecondsRoundedUp() const;
-  int64 InMicroseconds() const;
+  i64Bit::int64 InMilliseconds() const;
+  i64Bit::int64 InMillisecondsRoundedUp() const;
+  i64Bit::int64 InMicroseconds() const;
 
   TimeDelta& operator=(TimeDelta other) {
     delta_ = other.delta_;
@@ -114,21 +114,21 @@ class TimeDelta {
 
   // Computations with ints, note that we only allow multiplicative operations
   // with ints, and additive operations with other deltas.
-  TimeDelta operator*(int64 a) const {
+  TimeDelta operator*(i64Bit::int64 a) const {
     return TimeDelta(delta_ * a);
   }
-  TimeDelta operator/(int64 a) const {
+  TimeDelta operator/(i64Bit::int64 a) const {
     return TimeDelta(delta_ / a);
   }
-  TimeDelta& operator*=(int64 a) {
+  TimeDelta& operator*=(i64Bit::int64 a) {
     delta_ *= a;
     return *this;
   }
-  TimeDelta& operator/=(int64 a) {
+  TimeDelta& operator/=(i64Bit::int64 a) {
     delta_ /= a;
     return *this;
   }
-  int64 operator/(TimeDelta a) const {
+  i64Bit::int64 operator/(TimeDelta a) const {
     return delta_ / a.delta_;
   }
 
@@ -159,19 +159,19 @@ class TimeDelta {
  private:
   friend class Time;
   friend class TimeTicks;
-  friend TimeDelta operator*(int64 a, TimeDelta td);
+  friend TimeDelta operator*(i64Bit::int64 a, TimeDelta td);
 
   // Constructs a delta given the duration in microseconds. This is private
   // to avoid confusion by callers with an integer constructor. Use
   // FromSeconds, FromMilliseconds, etc. instead.
-  explicit TimeDelta(int64 delta_us) : delta_(delta_us) {
+  explicit TimeDelta(i64Bit::int64 delta_us) : delta_(delta_us) {
   }
 
   // Delta in microseconds.
-  int64 delta_;
+  i64Bit::int64 delta_;
 };
 
-inline TimeDelta operator*(int64 a, TimeDelta td) {
+inline TimeDelta operator*(i64Bit::int64 a, TimeDelta td) {
   return TimeDelta(a * td.delta_);
 }
 
@@ -180,16 +180,16 @@ inline TimeDelta operator*(int64 a, TimeDelta td) {
 // Represents a wall clock time.
 class Time {
  public:
-  static const int64 kMillisecondsPerSecond = 1000;
-  static const int64 kMicrosecondsPerMillisecond = 1000;
-  static const int64 kMicrosecondsPerSecond = kMicrosecondsPerMillisecond *
+  static const i64Bit::int64 kMillisecondsPerSecond = 1000;
+  static const i64Bit::int64 kMicrosecondsPerMillisecond = 1000;
+  static const i64Bit::int64 kMicrosecondsPerSecond = kMicrosecondsPerMillisecond *
                                               kMillisecondsPerSecond;
-  static const int64 kMicrosecondsPerMinute = kMicrosecondsPerSecond * 60;
-  static const int64 kMicrosecondsPerHour = kMicrosecondsPerMinute * 60;
-  static const int64 kMicrosecondsPerDay = kMicrosecondsPerHour * 24;
-  static const int64 kMicrosecondsPerWeek = kMicrosecondsPerDay * 7;
-  static const int64 kNanosecondsPerMicrosecond = 1000;
-  static const int64 kNanosecondsPerSecond = kNanosecondsPerMicrosecond *
+  static const i64Bit::int64 kMicrosecondsPerMinute = kMicrosecondsPerSecond * 60;
+  static const i64Bit::int64 kMicrosecondsPerHour = kMicrosecondsPerMinute * 60;
+  static const i64Bit::int64 kMicrosecondsPerDay = kMicrosecondsPerHour * 24;
+  static const i64Bit::int64 kMicrosecondsPerWeek = kMicrosecondsPerDay * 7;
+  static const i64Bit::int64 kNanosecondsPerMicrosecond = 1000;
+  static const i64Bit::int64 kNanosecondsPerSecond = kNanosecondsPerMicrosecond *
                                              kMicrosecondsPerSecond;
 
 #if !defined(OS_WIN)
@@ -198,7 +198,7 @@ class Time {
   // 1970-based epochs to the new 1601-based ones. It should be removed from
   // this global header and put in the platform-specific ones when we remove the
   // migration code.
-  static const int64 kWindowsEpochDeltaMicroseconds;
+  static const i64Bit::int64 kWindowsEpochDeltaMicroseconds;
 #endif
 
   // Represents an exploded time that can be formatted nicely. This is kind of
@@ -302,7 +302,7 @@ class Time {
   // when deserializing a |Time| structure, using a value known to be
   // compatible. It is not provided as a constructor because the integer type
   // may be unclear from the perspective of a caller.
-  static Time FromInternalValue(int64 us) {
+  static Time FromInternalValue(i64Bit::int64 us) {
     return Time(us);
   }
 
@@ -317,7 +317,7 @@ class Time {
   // For serializing, use FromInternalValue to reconstitute. Please don't use
   // this and do arithmetic on it, as it is more error prone than using the
   // provided operators.
-  int64 ToInternalValue() const {
+  i64Bit::int64 ToInternalValue() const {
     return us_;
   }
 
@@ -385,7 +385,7 @@ class Time {
  private:
   friend class TimeDelta;
 
-  explicit Time(int64 us) : us_(us) {
+  explicit Time(i64Bit::int64 us) : us_(us) {
   }
 
   // Explodes the given time to either local time |is_local = true| or UTC
@@ -398,7 +398,7 @@ class Time {
 
   // The representation of Jan 1, 1970 UTC in microseconds since the
   // platform-dependent epoch.
-  static const int64 kTimeTToMicrosecondsOffset;
+  static const i64Bit::int64 kTimeTToMicrosecondsOffset;
 
 #if defined(OS_WIN)
   // Indicates whether fast timers are usable right now.  For instance,
@@ -408,38 +408,38 @@ class Time {
 #endif
 
   // Time in microseconds in UTC.
-  int64 us_;
+  i64Bit::int64 us_;
 };
 
 // Inline the TimeDelta factory methods, for fast TimeDelta construction.
 
 // static
-inline TimeDelta TimeDelta::FromDays(int64 days) {
+inline TimeDelta TimeDelta::FromDays(i64Bit::int64 days) {
   return TimeDelta(days * Time::kMicrosecondsPerDay);
 }
 
 // static
-inline TimeDelta TimeDelta::FromHours(int64 hours) {
+inline TimeDelta TimeDelta::FromHours(i64Bit::int64 hours) {
   return TimeDelta(hours * Time::kMicrosecondsPerHour);
 }
 
 // static
-inline TimeDelta TimeDelta::FromMinutes(int64 minutes) {
+inline TimeDelta TimeDelta::FromMinutes(i64Bit::int64 minutes) {
   return TimeDelta(minutes * Time::kMicrosecondsPerMinute);
 }
 
 // static
-inline TimeDelta TimeDelta::FromSeconds(int64 secs) {
+inline TimeDelta TimeDelta::FromSeconds(i64Bit::int64 secs) {
   return TimeDelta(secs * Time::kMicrosecondsPerSecond);
 }
 
 // static
-inline TimeDelta TimeDelta::FromMilliseconds(int64 ms) {
+inline TimeDelta TimeDelta::FromMilliseconds(i64Bit::int64 ms) {
   return TimeDelta(ms * Time::kMicrosecondsPerMillisecond);
 }
 
 // static
-inline TimeDelta TimeDelta::FromMicroseconds(int64 us) {
+inline TimeDelta TimeDelta::FromMicroseconds(i64Bit::int64 us) {
   return TimeDelta(us);
 }
 
@@ -467,7 +467,7 @@ class TimeTicks {
 
 #if defined(OS_WIN)
   // Get the absolute value of QPC time drift. For testing.
-  static int64 GetQPCDriftMicroseconds();
+  static i64Bit::int64 GetQPCDriftMicroseconds();
 
   // Returns true if the high resolution clock is working on this system.
   // This is only for testing.
@@ -480,7 +480,7 @@ class TimeTicks {
   }
 
   // Returns the internal numeric value of the TimeTicks object.
-  int64 ToInternalValue() const {
+  i64Bit::int64 ToInternalValue() const {
     return ticks_;
   }
 
@@ -538,11 +538,11 @@ class TimeTicks {
 
   // Please use Now() to create a new object. This is for internal use
   // and testing. Ticks is in microseconds.
-  explicit TimeTicks(int64 ticks) : ticks_(ticks) {
+  explicit TimeTicks(i64Bit::int64 ticks) : ticks_(ticks) {
   }
 
   // Tick count in microseconds.
-  int64 ticks_;
+  i64Bit::int64 ticks_;
 
 #if defined(OS_WIN)
   typedef DWORD (*TickFunctionType)(void);

--- a/third_party/chromium_base/base/time_mac.cc
+++ b/third_party/chromium_base/base/time_mac.cc
@@ -32,24 +32,24 @@ namespace base {
 //   => Thu Jan 01 00:00:00 UTC 1970
 //   irb(main):011:0> Time.at(-11644473600).getutc()
 //   => Mon Jan 01 00:00:00 UTC 1601
-static const int64 kWindowsEpochDeltaSeconds = GG_INT64_C(11644473600);
-static const int64 kWindowsEpochDeltaMilliseconds =
+static const i64Bit::int64 kWindowsEpochDeltaSeconds = GG_INT64_C(11644473600);
+static const i64Bit::int64 kWindowsEpochDeltaMilliseconds =
     kWindowsEpochDeltaSeconds * Time::kMillisecondsPerSecond;
 
 // static
-const int64 Time::kWindowsEpochDeltaMicroseconds =
+const i64Bit::int64 Time::kWindowsEpochDeltaMicroseconds =
     kWindowsEpochDeltaSeconds * Time::kMicrosecondsPerSecond;
 
 // Some functions in time.cc use time_t directly, so we provide an offset
 // to convert from time_t (Unix epoch) and internal (Windows epoch).
 // static
-const int64 Time::kTimeTToMicrosecondsOffset = kWindowsEpochDeltaMicroseconds;
+const i64Bit::int64 Time::kTimeTToMicrosecondsOffset = kWindowsEpochDeltaMicroseconds;
 
 // static
 Time Time::Now() {
   CFAbsoluteTime now =
       CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970;
-  return Time(static_cast<int64>(now * kMicrosecondsPerSecond) +
+  return Time(static_cast<i64Bit::int64>(now * kMicrosecondsPerSecond) +
       kWindowsEpochDeltaMicroseconds);
 }
 
@@ -74,7 +74,7 @@ Time Time::FromExploded(bool is_local, const Exploded& exploded) {
       time_zone(is_local ? CFTimeZoneCopySystem() : NULL);
   CFAbsoluteTime seconds = CFGregorianDateGetAbsoluteTime(date, time_zone) +
       kCFAbsoluteTimeIntervalSince1970;
-  return Time(static_cast<int64>(seconds * kMicrosecondsPerSecond) +
+  return Time(static_cast<i64Bit::int64>(seconds * kMicrosecondsPerSecond) +
       kWindowsEpochDeltaMicroseconds);
 }
 

--- a/third_party/chromium_base/base/time_posix.cc
+++ b/third_party/chromium_base/base/time_posix.cc
@@ -15,7 +15,7 @@
 namespace base {
 
 struct timespec TimeDelta::ToTimeSpec() const {
-  int64 microseconds = InMicroseconds();
+  i64Bit::int64 microseconds = InMicroseconds();
   time_t seconds = 0;
   if (microseconds >= Time::kMicrosecondsPerSecond) {
     seconds = InSeconds();
@@ -40,18 +40,18 @@ struct timespec TimeDelta::ToTimeSpec() const {
 //   => Thu Jan 01 00:00:00 UTC 1970
 //   irb(main):011:0> Time.at(-11644473600).getutc()
 //   => Mon Jan 01 00:00:00 UTC 1601
-static const int64 kWindowsEpochDeltaSeconds = GG_INT64_C(11644473600);
-static const int64 kWindowsEpochDeltaMilliseconds =
+static const i64Bit::int64 kWindowsEpochDeltaSeconds = GG_INT64_C(11644473600);
+static const i64Bit::int64 kWindowsEpochDeltaMilliseconds =
     kWindowsEpochDeltaSeconds * Time::kMillisecondsPerSecond;
 
 // static
-const int64 Time::kWindowsEpochDeltaMicroseconds =
+const i64Bit::int64 Time::kWindowsEpochDeltaMicroseconds =
     kWindowsEpochDeltaSeconds * Time::kMicrosecondsPerSecond;
 
 // Some functions in time.cc use time_t directly, so we provide an offset
 // to convert from time_t (Unix epoch) and internal (Windows epoch).
 // static
-const int64 Time::kTimeTToMicrosecondsOffset = kWindowsEpochDeltaMicroseconds;
+const i64Bit::int64 Time::kTimeTToMicrosecondsOffset = kWindowsEpochDeltaMicroseconds;
 
 // static
 Time Time::Now() {
@@ -77,7 +77,7 @@ void Time::Explode(bool is_local, Exploded* exploded) const {
   // Time stores times with microsecond resolution, but Exploded only carries
   // millisecond resolution, so begin by being lossy.  Adjust from Windows
   // epoch (1601) to Unix epoch (1970);
-  int64 milliseconds = (us_ - kWindowsEpochDeltaMicroseconds) /
+  i64Bit::int64 milliseconds = (us_ - kWindowsEpochDeltaMicroseconds) /
       kMicrosecondsPerMillisecond;
   time_t seconds = milliseconds / kMillisecondsPerSecond;
 
@@ -118,7 +118,7 @@ Time Time::FromExploded(bool is_local, const Exploded& exploded) {
   else
     seconds = timegm(&timestruct);
 
-  int64 milliseconds;
+  i64Bit::int64 milliseconds;
   // Handle overflow.  Clamping the range to what mktime and timegm might
   // return is the best that can be done here.  It's not ideal, but it's better
   // than failing here or ignoring the overflow case and treating each time
@@ -173,8 +173,8 @@ TimeTicks TimeTicks::Now() {
   }
 
   absolute_micro =
-      (static_cast<int64>(ts.tv_sec) * Time::kMicrosecondsPerSecond) +
-      (static_cast<int64>(ts.tv_nsec) / Time::kNanosecondsPerMicrosecond);
+      (static_cast<i64Bit::int64>(ts.tv_sec) * Time::kMicrosecondsPerSecond) +
+      (static_cast<i64Bit::int64>(ts.tv_nsec) / Time::kNanosecondsPerMicrosecond);
 
   return TimeTicks(absolute_micro);
 }
@@ -192,7 +192,7 @@ TimeTicks TimeTicks::HighResNow() {
 
 struct timeval Time::ToTimeVal() const {
   struct timeval result;
-  int64 us = us_ - kTimeTToMicrosecondsOffset;
+  i64Bit::int64 us = us_ - kTimeTToMicrosecondsOffset;
   result.tv_sec = us / Time::kMicrosecondsPerSecond;
   result.tv_usec = us % Time::kMicrosecondsPerSecond;
   return result;


### PR DESCRIPTION
namespacing int64 chromium base type to allow 64-bit compile, preventing type conflict
