### PR TITLE
Fix for when file path not specified at command line

### DIFF
--- a/tests/testapp_softphone/test_configuration.cpp
+++ b/tests/testapp_softphone/test_configuration.cpp
@@ -55,7 +55,7 @@ const string TestConfiguration::NUMBERTODIAL = "numbertodial";
 const string TestConfiguration::USEBATCHMODE = "usebatchmode";
 
 
-TestConfiguration::TestConfiguration(void):_userNumber(), _userPassword(), _deviceName(), _sipProxyAddress(), _useVideo(false){
+TestConfiguration::TestConfiguration(void):_userNumber(), _userPassword(), _deviceName(), _sipProxyAddress(), _numberToDial(), _p2pAddress(), _useVideo(false), _useP2PMode(false), _useBatchMode(false){
 	
 }
 

--- a/tests/testapp_softphone/test_mac_cocoa.h
+++ b/tests/testapp_softphone/test_mac_cocoa.h
@@ -1,13 +1,40 @@
-/*
- *  Copyright (c) 2011 The WebRTC project authors. All Rights Reserved.
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *
- *  Use of this source code is governed by a BSD-style license
- *  that can be found in the LICENSE file in the root of the source
- *  tree. An additional intellectual property rights grant can be found
- *  in the file PATENTS.  All contributing project authors may
- *  be found in the AUTHORS file in the root of the source tree.
- */
-
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is the Cisco Systems SIP Stack.
+ *
+ * The Initial Developer of the Original Code is
+ * Cisco Systems (CSCO).
+ * Portions created by the Initial Developer are Copyright (C) 2002
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *  Cary Bran <cbran@cisco.com>
+ *  Ethan Hugg <ehugg@cisco.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
 
 #ifndef TEST_MAC_COCOA_H_
 #define TEST_MAC_COCOA_H_

--- a/tests/testapp_softphone/test_main.cc
+++ b/tests/testapp_softphone/test_main.cc
@@ -23,6 +23,7 @@
  *  Enda Mannion <emannion@cisco.com>
  *  Suhas Nandakumar <snandaku@cisco.com>
  *  Ethan Hugg <ehugg@cisco.com>
+ *  Cary Bran <cary.bran@gmail.com>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -396,8 +397,8 @@ void TestMain::GetP2POrSIP(){
 		}
 	}
 	//clean out any previous configurations
-	if (_state != STATE_REGISTERED) {
-		cout << "Switching to P2P mode unregistering with " << _config->GetSIPProxyAddress() << endl;
+	if (_state == STATE_REGISTERED) {
+		cout << "Switching mode unregistering with " << _config->GetSIPProxyAddress() << endl;
 		//assume this is already registered with CUCM, so unregister
 		SipccController::GetInstance()->UnRegister();
 		_state == STATE_NOT_REGISTERED;


### PR DESCRIPTION
Fixed file input problem: error was given if there was no file path
specified
Added Mozilla license to the a couple of files
