### PR TITLE
Fixed two issues in ROAPProxy

### DIFF
--- a/ikran/sipcc_controller.cpp
+++ b/ikran/sipcc_controller.cpp
@@ -455,6 +455,8 @@ void SipccController::onCallEvent (ccapi_call_event_e callEvent, CC_CallPtr call
 			if(observer_ != NULL)
 				observer_->OnCallResume();
 		}
+    } else if (callEvent == CCAPI_CALL_EV_CALLINFO) {
+    	observer_->OnCallConnected(sdp);
     }
 }
 

--- a/src/sipcc/core/sipstack/ccsip_core.c
+++ b/src/sipcc/core/sipstack/ccsip_core.c
@@ -3625,6 +3625,7 @@ ccsip_handle_idle_ev_cc_setup (ccsipCCB_t *ccb, sipSMEvent_t *event)
 	
 	if (roapproxy == TRUE) {
 		strcpy(ccb->local_msg_body.parts[0].body,gROAPSDP.sdp);
+		strcpy(gROAPSDP.sdp,"");
 	} else {
 		strcpy(gROAPSDP.sdp, ccb->local_msg_body.parts[0].body);
 	}
@@ -3949,7 +3950,8 @@ ccsip_handle_sentinvite_ev_sip_2xx (ccsipCCB_t *ccb, sipSMEvent_t *event)
 	config_get_value(CFGID_ROAPPROXY, &roapproxy, sizeof(roapproxy));
 	
 	if (roapproxy == TRUE) {
-		strcpy(gROAPSDP.sdp, ccb->local_msg_body.parts[0].body);
+		//strcpy(gROAPSDP.sdp, ccb->local_msg_body.parts[0].body);
+		strcpy(gROAPSDP.sdp, response->mesg_body->msgBody);
 	}
 	//
 

--- a/tests/roap/incomingroap.cpp
+++ b/tests/roap/incomingroap.cpp
@@ -81,7 +81,7 @@ void IncomingRoap::Offer(string callerSessionId, string seq, string sdp)
   else
   {
     SipccController::GetInstance()->PlaceCall(callerSessionId, sdp);
-    roapProxyCallState = CALLSTATE_IN_CALL;
+    //roapProxyCallState = CALLSTATE_IN_CALL;
   }
 }
 

--- a/tests/roap/outgoingroap.cpp
+++ b/tests/roap/outgoingroap.cpp
@@ -146,7 +146,8 @@ void OutgoingRoap::OnCallTerminated()
 
 void OutgoingRoap::OnCallConnected(char* sdp)
 {
-	Answer("callerSessionId", "calleeSessionId", "seq", sdp);
+	if (strcmp(sdp,"") != 0)
+		Answer("callerSessionId", "calleeSessionId", "seq", sdp);
 }
 
 void OutgoingRoap::OnCallHeld()


### PR DESCRIPTION
1.  CALLSTATE_REGISTERED was being replaced with CALLSTATE_IN_CALL, then second call was not getting through.
2.  ccsip_core.c the the OFFER SDP was being used instead of the Answer SDP on OK from remote phone, this was not the case on Windows.
